### PR TITLE
問題の遷移

### DIFF
--- a/Assets/Scenes/QuizScene.unity
+++ b/Assets/Scenes/QuizScene.unity
@@ -2779,6 +2779,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1066697647}
   - component: {fileID: 1066697648}
+  - component: {fileID: 1066697649}
   m_Layer: 0
   m_Name: MakeConnectionToGPT
   m_TagString: Untagged
@@ -2811,6 +2812,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a58951db71f704973b82c7f3bd9e36d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1066697649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066697646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 452e66bd714244d45a60c1868241372f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1168500357

--- a/Assets/Scripts/MessageGeter.cs
+++ b/Assets/Scripts/MessageGeter.cs
@@ -10,6 +10,7 @@ using TMPro;
 
 public class MessageGeter : MonoBehaviour
 {
+    public MessageManager messageManager;
     private string Request_sentence;
     public struct Question
     {
@@ -21,8 +22,6 @@ public class MessageGeter : MonoBehaviour
         public int answer_index;
     }
     public Question[] question = new Question[3];
-    public MessageManager messageManager;
-
     private async UniTask GenerateMessage(string str)
     {
         var chatGPTConnection = new ChatGPTConnection();
@@ -49,6 +48,7 @@ public class MessageGeter : MonoBehaviour
                 question[i].sel_4 = lines[lines_index+4];
                 question[i].answer_index = int.Parse(Regex.Replace (lines[lines_index+5], @"[^0-9]", ""));
             }
+            messageManager.Q_Displaycontrol();
         }
     }
 

--- a/Assets/Scripts/MessageManager.cs
+++ b/Assets/Scripts/MessageManager.cs
@@ -7,8 +7,12 @@ using TMPro;
 public class MessageManager : MonoBehaviour
 {
     [SerializeField] private int MAXQUESTIONINDEX;
-
+    public Timer timer;
     public MessageGeter messageGeter;
+    public SetButton setButton1;
+    public SetButton setButton2;
+    public SetButton setButton3;
+    public SetButton setButton4;
     public StoreButtonData storeButtonData;
     public TextMeshProUGUI sentence_box;
     public TextMeshProUGUI sel_1_box;
@@ -17,10 +21,10 @@ public class MessageManager : MonoBehaviour
     public TextMeshProUGUI sel_4_box;
     public TextMeshProUGUI answer_index_box;
     public TextMeshProUGUI selected_index_box;
+
     [SerializeField] private int NowQuestionIndex;
 
-    // Update is called once per frame
-    void Update()
+    public void Q_Displaycontrol()
     {
         sentence_box.text = messageGeter.question[NowQuestionIndex].sentence;
         sel_1_box.text = messageGeter.question[NowQuestionIndex].sel_1;
@@ -28,10 +32,23 @@ public class MessageManager : MonoBehaviour
         sel_3_box.text = messageGeter.question[NowQuestionIndex].sel_3;
         sel_4_box.text = messageGeter.question[NowQuestionIndex].sel_4;
         answer_index_box.text = messageGeter.question[NowQuestionIndex].answer_index.ToString("0");
-        if (storeButtonData.data.Count == 0) return;
-        selected_index_box.text = storeButtonData.data[storeButtonData.data.Count-1].id.ToString("0");
+        //if (storeButtonData.data.Count == 0) return;
+        //selected_index_box.text = storeButtonData.data[NowQuestionIndex].id.ToString("0");
+        timer.GoTimer();
     }
-    
+    public void NextQuestion(){
+        NowQuestionIndex+=1;
+        if(NowQuestionIndex < 3){
+            Q_Displaycontrol();
+            setButton1.InitButton();
+            setButton2.InitButton();
+            setButton3.InitButton();
+            setButton4.InitButton();
+        }
+        else{
+            Debug.Log("error");
+        }
+    }
     public void SetQuestionIndex(int idx)
     {
         NowQuestionIndex = idx;

--- a/Assets/Scripts/SetButton.cs
+++ b/Assets/Scripts/SetButton.cs
@@ -8,6 +8,7 @@ public class SetButton : MonoBehaviour
 {
     public Timer timer;
     public StoreButtonData data;
+    public MessageManager messageManager;
     private float timeUp;
     private float timeStop; 
     private int idx;
@@ -15,7 +16,6 @@ public class SetButton : MonoBehaviour
  
 
     void Start(){
-        timer.GoTimer();
         InitButton();
     }
     void Update()
@@ -23,21 +23,16 @@ public class SetButton : MonoBehaviour
         //Debug.Log("Update method called");
         timeUp = timer.GetTimeUp();
         //Debug.Log(timeUp);
-        if(click){
+        if(timeUp == 10.0 && !click){
             //Debug.Log("Condition met");
+            timeStop = 10.0f;//タイマーの上限値に変更
             StoreInfo();
-            timer.GoTimer();
+            messageManager.NextQuestion();
             InitButton();
-        }
-        if(timeUp == 10.0){
-            //Debug.Log("Condition met");
-            timeStop = 10.0f;
-            StoreInfo();
-            timer.GoTimer();
-            InitButton();
+            click = true;
         }
     }
-    private void InitButton(){
+    public void InitButton(){
         idx = 0;
         click = false;
         ButtonAct();
@@ -79,8 +74,9 @@ public class SetButton : MonoBehaviour
         timeStop = timeUp;
         timeStop = Mathf.Max(timeStop, 0) % 60;
         click = true;
-
+        StoreInfo();
         ButtonNotAct();
+        messageManager.NextQuestion();
     }
     public void StoreInfo(){
         data.DataSave(idx, timeStop);

--- a/Assets/Scripts/StoreButtonData.cs
+++ b/Assets/Scripts/StoreButtonData.cs
@@ -3,32 +3,29 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public struct Data
-{
-    public int id;
-    public float time;
-
-    public Data(int id, float time)
-    {
-        this.id = id;
-        this.time = time;
-    }
-}
-
 public class StoreButtonData : MonoBehaviour{
-    public List<Data> data;
-    void Start()
-    {
-        data = new List<Data>();
+    public struct Data{
+        public int id;
+        public float time;
     }
+
+    public Data[] data = new Data[3];//問題数に応じて変更
+    public MessageManager messageManager;
+    private int i;
     public void DataSave(int idx, float timeStop){
-        Data dt = new Data();
-        dt.id = idx;
-        dt.time = timeStop;
-        data.Add(dt);
-        for (int i = 0; i < data.Count; i++)
-        {
-            //Debug.Log("Data at index " + i + ": idx = " + data[i].id + ", timeStop = " + data[i].time);
+        i = messageManager.GetQuestionIndex();
+        if(i<3){
+            data[i].id = idx;
+            data[i].time = timeStop;
+            Debug.Log(i + "回目");
+            for (int j = 0; j < i + 1; j++)
+            {
+                Debug.Log("Data at index " + j + ": idx = " + data[j].id + ", timeStop = " + data[j].time);
+            }
+            i += 1;
+        }
+        else{
+            Debug.Log("error");
         }
     }
 }

--- a/Assets/test.txt.meta
+++ b/Assets/test.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c40c49697b21d904ca69ceede3b6fc80
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
mainにrequest送ります．
以下コピペ
追加機能
ボタンを押すまたは10秒経過で次の問題に遷移する

以下追加機能に伴う改変点
timerのスタートを"問題文などが表示されたら"に変更
timerが10秒到達後無限にボタンの秒数とindexを保存するバグを改善
ボタンの秒数とindexを保存する機能をLISTを使用しない方式に変更
問題文などの表示をUPDATEから問題文を構造体に格納し終わったら、次の問題に遷移するときに変更