### PR TITLE
文字が１文字ずつ表示されるようにしたぞ！！！！

### DIFF
--- a/Assets/Scenes/GeneScene.unity
+++ b/Assets/Scenes/GeneScene.unity
@@ -270,6 +270,7 @@ GameObject:
   - component: {fileID: 46637953}
   - component: {fileID: 46637952}
   - component: {fileID: 46637951}
+  - component: {fileID: 46637955}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -354,6 +355,7 @@ RectTransform:
   - {fileID: 645960501}
   - {fileID: 244720513}
   - {fileID: 1687202993}
+  - {fileID: 1686387554}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -362,6 +364,20 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &46637955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46637950}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44fa230acc382473caf690be8dd974e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GeneratingText: {fileID: 2087279643}
+  GeneratePanel: {fileID: 1686387551}
 --- !u!1 &244720512
 GameObject:
   m_ObjectHideFlags: 0
@@ -1353,6 +1369,83 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1428259886}
   m_CullTransparentMesh: 1
+--- !u!1 &1686387551
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1686387554}
+  - component: {fileID: 1686387553}
+  - component: {fileID: 1686387552}
+  m_Layer: 5
+  m_Name: GeneratePanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &1686387552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1686387551}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.79607844}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1686387553
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1686387551}
+  m_CullTransparentMesh: 1
+--- !u!224 &1686387554
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1686387551}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2087279641}
+  m_Father: {fileID: 46637954}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1687202992
 GameObject:
   m_ObjectHideFlags: 0
@@ -1610,3 +1703,138 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MAXQUESTIONINDEX: 3
+--- !u!1 &2087279640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2087279641}
+  - component: {fileID: 2087279642}
+  - component: {fileID: 2087279643}
+  m_Layer: 5
+  m_Name: GeneratingText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2087279641
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087279640}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1686387554}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2087279642
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087279640}
+  m_CullTransparentMesh: 1
+--- !u!114 &2087279643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087279640}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "(\u751F\u6210\u4E2D\u306E\u30C6\u30AD\u30B9\u30C8)"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 4d3d90c4843464cefaecee0111a5a0a7, type: 2}
+  m_sharedMaterial: {fileID: 7643409143741675415, guid: 4d3d90c4843464cefaecee0111a5a0a7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/Scenes/QuizScene.unity
+++ b/Assets/Scenes/QuizScene.unity
@@ -1962,6 +1962,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MAXQUESTIONINDEX: 3
+  NowQuestionIndex: 0
+  DELAYSHOWFRAME: 20
   timer: {fileID: 1059775566}
   setButton1: {fileID: 210107106}
   setButton2: {fileID: 556368026}
@@ -1973,7 +1975,6 @@ MonoBehaviour:
   sel_2_box: {fileID: 142840667}
   sel_3_box: {fileID: 1785788563}
   sel_4_box: {fileID: 1689858358}
-  NowQuestionIndex: 0
 --- !u!1 &1179511261
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GeneUIManager.cs
+++ b/Assets/Scripts/GeneUIManager.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class GeneUIManager : MonoBehaviour
+{
+    public static GeneUIManager instance;
+    [SerializeField] TextMeshProUGUI GeneratingText;
+    [SerializeField] GameObject GeneratePanel;
+
+    private void Awake()
+    {
+        instance = this;
+    }
+
+    public void CloseGeneUI()
+    {
+        GeneratePanel.SetActive(false);
+    }
+
+    public void GeneratingUIDisplay()
+    {
+        CloseGeneUI();
+        GeneratePanel.SetActive(true);
+
+    }
+
+    public void SetGeneratingText(string _text)
+    {
+        GeneratingText.text = _text;
+    }
+}

--- a/Assets/Scripts/GeneUIManager.cs.meta
+++ b/Assets/Scripts/GeneUIManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44fa230acc382473caf690be8dd974e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MessageGeter.cs
+++ b/Assets/Scripts/MessageGeter.cs
@@ -25,7 +25,8 @@ public class MessageGeter : MonoBehaviour
     public static Question[] question = new Question[3];
     private async UniTask GenerateMessage(string str)
     {
-        Debug.Log("生成中・・");
+        GeneUIManager.instance.SetGeneratingText("生成中・・・");
+        GeneUIManager.instance.GeneratingUIDisplay();
         // APIは使用料かかるのでダミーデータをquestion[i]に入れるようにします
         //少し生成を待つコード(雰囲気的に)
         await UniTask.DelayFrame(500);
@@ -58,8 +59,9 @@ public class MessageGeter : MonoBehaviour
                 question[i].answer_index = int.Parse(Regex.Replace (lines[lines_index+5], @"[^0-9]", ""));
             }
         }
-        Debug.Log("格納完了");
+        GeneUIManager.instance.SetGeneratingText("生成完了！");
         await UniTask.DelayFrame(300);
+        GeneUIManager.instance.CloseGeneUI();
         SceneManager.LoadScene("QuizScene");
     }
 

--- a/Assets/Scripts/MessageManager.cs
+++ b/Assets/Scripts/MessageManager.cs
@@ -9,8 +9,10 @@ using TMPro;
 public class MessageManager : MonoBehaviour
 {
     [SerializeField] private int MAXQUESTIONINDEX;
-    public Timer timer;
+    [SerializeField] private int NowQuestionIndex;
+    [SerializeField] private int DELAYSHOWFRAME;
 
+    public Timer timer;
     public SetButton setButton1;
     public SetButton setButton2;
     public SetButton setButton3;
@@ -22,38 +24,65 @@ public class MessageManager : MonoBehaviour
     public TextMeshProUGUI sel_3_box;
     public TextMeshProUGUI sel_4_box;
 
-    [SerializeField] private int NowQuestionIndex;
-
-    void Start()
+    async void Start()
     {
-        Q_Displaycontrol();
+        await Q_Displaycontrol();
     }  
-    public void Q_Displaycontrol()
+
+    public async UniTask Q_Displaycontrol()
     {
-        sentence_box.text = MessageGeter.question[NowQuestionIndex].sentence;
-        sel_1_box.text = MessageGeter.question[NowQuestionIndex].sel_1;
-        sel_2_box.text = MessageGeter.question[NowQuestionIndex].sel_2;
-        sel_3_box.text = MessageGeter.question[NowQuestionIndex].sel_3;
-        sel_4_box.text = MessageGeter.question[NowQuestionIndex].sel_4;
-        //if (storeButtonData.data.Count == 0) return;
-        //selected_index_box.text = storeButtonData.data[NowQuestionIndex].id.ToString("0");
+        ClearQuizSet();
+        await Show(sentence_box, MessageGeter.question[NowQuestionIndex].sentence);
+        await Show(sel_1_box, MessageGeter.question[NowQuestionIndex].sel_1);
+        await Show(sel_2_box, MessageGeter.question[NowQuestionIndex].sel_2);
+        await Show(sel_3_box, MessageGeter.question[NowQuestionIndex].sel_3);
+        await Show(sel_4_box, MessageGeter.question[NowQuestionIndex].sel_4);
+        InitButtons();
         timer.GoTimer();
     }
-    public async UniTask NextQuestion(){
-        NowQuestionIndex+=1;
-        if(NowQuestionIndex < 3){
-            Q_Displaycontrol();
-            setButton1.InitButton();
-            setButton2.InitButton();
-            setButton3.InitButton();
-            setButton4.InitButton();
-        }
-        else{
+
+    public async void NextQuestion(){
+        NowQuestionIndex++;
+        if (NowQuestionIndex+1 > MessageGeter.question.Length)
+        {
             Debug.Log("問題終了");
             await UniTask.DelayFrame(300);
             SceneManager.LoadScene("ResultScene");
+            return;
         }
+        await Q_Displaycontrol();
     }
+
+    //表示上限数を1ずつ上げることで、いい感じに文字表示する関数
+    public async UniTask Show(TextMeshProUGUI _box, string _text)
+    {
+        for (int i=0; i<_text.Length; i++)
+        {
+            _box.maxVisibleCharacters = i;
+            _box.text = _text;
+            //DELAYSHOWFRAMEだけ待つ
+            await UniTask.DelayFrame(DELAYSHOWFRAME);
+        }
+        _box.maxVisibleCharacters = _text.Length;
+    }
+
+    // 文章が入るボックスを綺麗にする関数
+    public void ClearQuizSet()
+    {
+        sentence_box.text = null;
+        sel_1_box.text = null;
+        sel_2_box.text = null;
+        sel_3_box.text = null;
+        sel_4_box.text = null;
+    }
+    public void InitButtons()
+    {
+        setButton1.InitButton();
+        setButton2.InitButton();
+        setButton3.InitButton();
+        setButton4.InitButton();
+    }
+
     public void SetQuestionIndex(int idx)
     {
         NowQuestionIndex = idx;

--- a/Assets/Scripts/MessageManager.cs
+++ b/Assets/Scripts/MessageManager.cs
@@ -37,7 +37,6 @@ public class MessageManager : MonoBehaviour
         await Show(sel_2_box, MessageGeter.question[NowQuestionIndex].sel_2);
         await Show(sel_3_box, MessageGeter.question[NowQuestionIndex].sel_3);
         await Show(sel_4_box, MessageGeter.question[NowQuestionIndex].sel_4);
-        InitButtons();
         timer.GoTimer();
     }
 
@@ -50,6 +49,7 @@ public class MessageManager : MonoBehaviour
             SceneManager.LoadScene("ResultScene");
             return;
         }
+        InitButtons();
         await Q_Displaycontrol();
     }
 

--- a/Assets/Scripts/SetButton.cs
+++ b/Assets/Scripts/SetButton.cs
@@ -17,6 +17,7 @@ public class SetButton : MonoBehaviour
 
     void Start(){
         InitButton();
+        ButtonNotAct();
     }
     void Update()
     {


### PR DESCRIPTION
## 変更内容

- GeneSceneのUI管理を行うスクリプト"GeneUIManager.cs"を追加した
- 問題文・選択肢が、抒情的に１文字ずつ表示されるようにした

## 備考

- GeneUIManager.csは、publicでつけた"Panel"というUIのゲームオブジェクトをアクティブにしたり非アクティブにしたりしてる
- １文字ずつの表示は、文章が入る箱についてるTestMeshProのメンバの`.maxVisibleCharacters`をUniTaskの待つ機能でゆっくり変更することで実装した
- 例外処理の条件分岐は例外側を先に書いてreturnすると、処理が地続きになる(好みかも)

```c#
//例外処理をelseでやる場合
public async void NextQuestion()
{
        NowQuestionIndex+=1;
        if(NowQuestionIndex < 3){
            Q_Displaycontrol();
            InitButtons();
        }
        else{
            Debug.Log("問題終了");
            await UniTask.DelayFrame(300);
            SceneManager.LoadScene("ResultScene");
        }
        await Q_Displaycontrol();
}
```

```c#
//例外処理を先にやる場合
public async void NextQuestion()
{
        NowQuestionIndex++;
        if (NowQuestionIndex+1 > MessageGeter.question.Length)
        {
            Debug.Log("問題終了");
            await UniTask.DelayFrame(300);
            SceneManager.LoadScene("ResultScene");
            return;
        }

        InitButtons();
        await Q_Displaycontrol();
}
``` 
