### PR TITLE
UniTaskのDelayFrameを使うのをやめて、Delayにした

### DIFF
--- a/Assets/Scenes/QuizScene.unity
+++ b/Assets/Scenes/QuizScene.unity
@@ -1963,7 +1963,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   MAXQUESTIONINDEX: 3
   NowQuestionIndex: 0
-  DELAYSHOWFRAME: 40
+  DELAYSHOWMS: 50
   timer: {fileID: 1059775566}
   setButton1: {fileID: 210107106}
   setButton2: {fileID: 556368026}

--- a/Assets/Scripts/MessageGeter.cs
+++ b/Assets/Scripts/MessageGeter.cs
@@ -29,7 +29,7 @@ public class MessageGeter : MonoBehaviour
         GeneUIManager.instance.GeneratingUIDisplay();
         // APIは使用料かかるのでダミーデータをquestion[i]に入れるようにします
         //少し生成を待つコード(雰囲気的に)
-        await UniTask.DelayFrame(500);
+        await UniTask.Delay(1200);
         string[] lines = new string[] {"問題1の文章","Q1_select1","Q1_select2","Q1_select3","Q1_select4","Q1_answerIndex",
                                         "問題2の文章","Q2_select1","Q2_select2","Q2_select3","Q2_select4","Q1_answerIndex",
                                         "問題3の文章","Q3_select1","Q3_select2","Q3_select3","Q3_select4","Q1_answerIndex"};
@@ -60,7 +60,7 @@ public class MessageGeter : MonoBehaviour
             }
         }
         GeneUIManager.instance.SetGeneratingText("生成完了！");
-        await UniTask.DelayFrame(300);
+        await UniTask.Delay(500);
         GeneUIManager.instance.CloseGeneUI();
         SceneManager.LoadScene("QuizScene");
     }

--- a/Assets/Scripts/MessageManager.cs
+++ b/Assets/Scripts/MessageManager.cs
@@ -10,7 +10,7 @@ public class MessageManager : MonoBehaviour
 {
     [SerializeField] private int MAXQUESTIONINDEX;
     [SerializeField] private int NowQuestionIndex;
-    [SerializeField] private int DELAYSHOWFRAME;
+    [SerializeField] private int DELAYSHOWMS;
 
     public Timer timer;
     public SetButton setButton1;
@@ -33,7 +33,7 @@ public class MessageManager : MonoBehaviour
     {
         ClearQuizSet();
         await Show(sentence_box, MessageGeter.question[NowQuestionIndex].sentence);
-        await UniTask.DelayFrame(500);
+        await UniTask.Delay(1000);
         sel_1_box.text = MessageGeter.question[NowQuestionIndex].sel_1;
         sel_2_box.text = MessageGeter.question[NowQuestionIndex].sel_2;
         sel_3_box.text = MessageGeter.question[NowQuestionIndex].sel_3;
@@ -47,7 +47,7 @@ public class MessageManager : MonoBehaviour
         if (NowQuestionIndex+1 > MessageGeter.question.Length)
         {
             Debug.Log("問題終了");
-            await UniTask.DelayFrame(300);
+            await UniTask.Delay(1500);
             SceneManager.LoadScene("ResultScene");
             return;
         }
@@ -62,7 +62,7 @@ public class MessageManager : MonoBehaviour
             _box.maxVisibleCharacters = i;
             _box.text = _text;
             //DELAYSHOWFRAMEだけ待つ
-            await UniTask.DelayFrame(DELAYSHOWFRAME);
+            await UniTask.Delay(DELAYSHOWMS);
         }
         _box.maxVisibleCharacters = _text.Length;
     }


### PR DESCRIPTION
Issue #40 解決版
## 変更内容

- `await UniTask.DelayFrame(int)`を使っていた箇所を、`await UniTask.Delay(int)`に変更した

## 備考

- UniTask.Delay()の中身はmsが入る。`await UniTask.Delay(1000)` = 1秒まつ
- Delayの内部的には、UnityのTime.deltaTimeを用いて数え上げているらしい。Time.deltaTimeは前に読まれたフレームとの秒差分を返す変数で、FPS環境が違っても大きな秒数の差が出なくなるはず